### PR TITLE
Do not camelize string value of an object

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -26,8 +26,7 @@ export const camelize = (str: string) => {
 export const camelizeDeep = <T extends unknown>(
   obj: T,
 ): T extends string ? string : CamelizeDeep<T> => {
-  return Array.isArray(obj) ? obj.map(camelizeDeep) : // NOTE: Eliminate class instances like Date, Set, RegExp, etc.
-    !isPlainObject(obj)
+  return Array.isArray(obj) ? obj.map(camelizeDeep) : !isPlainObject(obj) // Eliminate class instances like Date, Set, RegExp, etc.
     ? obj
     : Object.keys(obj).reduce((acc, key) => {
       const camelizedKey = camelize(key);

--- a/mod.ts
+++ b/mod.ts
@@ -26,17 +26,13 @@ export const camelize = (str: string) => {
 export const camelizeDeep = <T extends unknown>(
   obj: T,
 ): T extends string ? string : CamelizeDeep<T> => {
-  return typeof obj === "string"
-    ? camelize(obj)
-    : Array.isArray(obj)
-    ? obj.map(camelizeDeep)
-    : // NOTE: Eliminate class instances like Date, Set, RegExp, etc.
-      !isPlainObject(obj)
-      ? obj
-      : Object.keys(obj).reduce((acc, key) => {
-        const camelizedKey = camelize(key);
-        acc[camelizedKey] = camelizeDeep(obj[key]);
-        return acc;
-        // deno-lint-ignore no-explicit-any
-      }, {} as any);
+  return Array.isArray(obj) ? obj.map(camelizeDeep) : // NOTE: Eliminate class instances like Date, Set, RegExp, etc.
+    !isPlainObject(obj)
+    ? obj
+    : Object.keys(obj).reduce((acc, key) => {
+      const camelizedKey = camelize(key);
+      acc[camelizedKey] = camelizeDeep(obj[key]);
+      return acc;
+      // deno-lint-ignore no-explicit-any
+    }, {} as any);
 };

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -49,6 +49,7 @@ Deno.test("camelizeDeep: Object with Array", () => {
           is_confirmed: false,
         },
       ],
+      created_at: "2022-01-01T00:00:00.000",
     }),
     {
       userId: 123,
@@ -62,6 +63,7 @@ Deno.test("camelizeDeep: Object with Array", () => {
           isConfirmed: false,
         },
       ],
+      createdAt: "2022-01-01T00:00:00.000",
     },
   );
 });


### PR DESCRIPTION
## AsIs
camelizeDeep converts a string value of an object to camelCase.
```typescript
// { a: "fooBar" }
console.log(camelizeDeep({ a: "foo_bar" }));
```

## ToBe
It should be `{ a: "foo_bar" }`.
